### PR TITLE
Implement max connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ h2 = "0.1.5"
 iovec = "0.1"
 log = "0.4"
 net2 = { version = "0.2.32", optional = true }
+raii-counter = "0.1"
 time = "0.1"
 tokio = { version = "0.1.7", optional = true }
 tokio-executor = { version = "0.1.0", optional = true }
@@ -138,4 +139,3 @@ required-features = ["runtime"]
 name = "server"
 path = "tests/server.rs"
 required-features = ["runtime"]
-

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -640,7 +640,7 @@ pub struct Builder {
     exec: Exec,
     keep_alive: bool,
     keep_alive_timeout: Option<Duration>,
-    idle_connection_max: Option<usize>,
+    max_idle_connections: Option<usize>,
     h1_writev: bool,
     h1_title_case_headers: bool,
     //TODO: make use of max_idle config
@@ -656,7 +656,7 @@ impl Default for Builder {
             exec: Exec::Default,
             keep_alive: true,
             keep_alive_timeout: Some(Duration::from_secs(90)),
-            idle_connection_max: None,
+            max_idle_connections: None,
             h1_writev: true,
             h1_title_case_headers: false,
             max_idle: 5,
@@ -697,8 +697,8 @@ impl Builder {
     ///
     /// Default is 'None'
     #[inline]
-    pub fn idle_connection_max<D>(&mut self, val: Option<usize>) -> &mut Self {
-        self.idle_connection_max = val;
+    pub fn max_idle_connections<D>(&mut self, val: Option<usize>) -> &mut Self {
+        self.max_idle_connections = val;
         self
     }
 
@@ -810,7 +810,7 @@ impl Builder {
             pool: Pool::new(
                 self.keep_alive,
                 self.keep_alive_timeout,
-                self.idle_connection_max,
+                self.max_idle_connections,
                 &self.exec
             ),
             retry_canceled_requests: self.retry_canceled_requests,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -697,8 +697,11 @@ impl Builder {
     ///
     /// Default is 'None'
     #[inline]
-    pub fn max_idle_connections<D>(&mut self, val: Option<usize>) -> &mut Self {
-        self.max_idle_connections = val;
+    pub fn max_idle_connections<V>(&mut self, val: V) -> &mut Self
+    where
+        V: Into<Option<usize>>,
+    {
+        self.max_idle_connections = val.into();
         self
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -383,16 +383,10 @@ where C: Connect + Sync + 'static,
                                 future::ok::<Pooled<_>, ClientError<_>>(pooled)
                             })))
                         },
-                        Ok(Either::B((connect_res, checkout))) => {
+                        Ok(Either::B((connect_res, _checkout))) => {
                             Either::A(PooledFuture::ConnectFin(
                                 connect2pooled(connect_res)
-                                    .or_else(move |e| {
-                                        if e.is_canceled() {
-                                            Either::A(checkout.map_err(ClientError::Normal))
-                                        } else {
-                                            Either::B(future::err(ClientError::Normal(e)))
-                                        }
-                                    })
+                                    .map_err(ClientError::Normal)
                             ))
                     },
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -640,7 +640,7 @@ pub struct Builder {
     exec: Exec,
     keep_alive: bool,
     keep_alive_timeout: Option<Duration>,
-    max_idle_connections: Option<usize>,
+    max_connections: Option<usize>,
     h1_writev: bool,
     h1_title_case_headers: bool,
     //TODO: make use of max_idle config
@@ -656,7 +656,7 @@ impl Default for Builder {
             exec: Exec::Default,
             keep_alive: true,
             keep_alive_timeout: Some(Duration::from_secs(90)),
-            max_idle_connections: None,
+            max_connections: None,
             h1_writev: true,
             h1_title_case_headers: false,
             max_idle: 5,
@@ -697,11 +697,11 @@ impl Builder {
     ///
     /// Default is 'None'
     #[inline]
-    pub fn max_idle_connections<V>(&mut self, val: V) -> &mut Self
+    pub fn max_connections<V>(&mut self, val: V) -> &mut Self
     where
         V: Into<Option<usize>>,
     {
-        self.max_idle_connections = val.into();
+        self.max_connections = val.into();
         self
     }
 
@@ -813,7 +813,7 @@ impl Builder {
             pool: Pool::new(
                 self.keep_alive,
                 self.keep_alive_timeout,
-                self.max_idle_connections,
+                self.max_connections,
                 &self.exec
             ),
             retry_canceled_requests: self.retry_canceled_requests,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -691,7 +691,10 @@ impl Builder {
         self
     }
 
-    /// Set an optional maximum for idle sockets being kept-alive.
+    /// Set an optional maximum for connections. Requests beyond this limit
+    /// will wait for an re-usable connection, failing if no re-usable connection
+    /// will exist (no active connections for the same Key).
+    ///
     /// This is local to the client and will not synchronize across
     /// multiple clients.
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -317,7 +317,7 @@ where C: Connect + Sync + 'static,
                 //
                 // 1. Connect is canceled if this is HTTP/2 and there is
                 //    an outstanding HTTP/2 connecting task OR this is HTTP/1
-                //    and there are too many idle connections.
+                //    and there are too many connections.
                 // 2. Checkout is canceled if the pool cannot deliver an
                 //    idle connection reliably.
                 //

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -198,21 +198,11 @@ impl<T: Poolable> Pool<T> {
             },
             Ver::Http1 => {
                 let can_connect_counter = {
-                    let mut connections = self.inner.connections.lock().unwrap();
-                    let mut can_connect = connections
+                    let connections = self.inner.connections.lock().unwrap();
+                    let can_connect = connections
                         .max_connections
                         .map(|max| connections.conns_count.count() < max)
                         .unwrap_or(true);
-
-                    // check if we can evict an Idle connection
-                    // before making a new connection
-                    if !can_connect {
-                        can_connect = connections.idle
-                            .values_mut()
-                            .any(|v| {
-                                v.pop().is_some()
-                            });
-                    }
 
                     if can_connect {
                         Some(connections.conns_count.spawn_upgrade())

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -66,7 +66,10 @@ struct Connections<T> {
     // This is used to keep a maximum bound on the number of connections
     // This is a WeakCounter so it is not counted towards the Conns count.
     conns_count: WeakCounter,
-    // A maximum number of idle connections
+    // An optional maximum number of connections. HTTP/1 requests will
+    // not create a new connection if this limit is reached, they will instead
+    // wait to re-use a new idle connection or error if no idle connection will
+    // be possible (no active requests for the Key).
     max_connections: Option<usize>,
     // These are outstanding Checkouts that are waiting for a socket to be
     // able to send a Request one. This is used when "racing" for a new

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -198,11 +198,21 @@ impl<T: Poolable> Pool<T> {
             },
             Ver::Http1 => {
                 let can_connect_counter = {
-                    let connections = self.inner.connections.lock().unwrap();
-                    let can_connect = connections
+                    let mut connections = self.inner.connections.lock().unwrap();
+                    let mut can_connect = connections
                         .max_connections
                         .map(|max| connections.conns_count.count() < max)
                         .unwrap_or(true);
+
+                    // check if we can evict an Idle connection
+                    // before making a new connection
+                    if !can_connect {
+                        can_connect = connections.idle
+                            .values_mut()
+                            .any(|v| {
+                                v.pop().is_some()
+                            });
+                    }
 
                     if can_connect {
                         Some(connections.conns_count.spawn_upgrade())

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -331,6 +331,7 @@ impl<'a, T: Poolable + 'a> IdlePopper<'a, T> {
             // If the connection has been closed, or is older than our idle
             // timeout, simply drop it and keep looking...
             if !entry.value.is_open() {
+                error!("IdlePopper; remove closed conn | key: {:?}", self.key);
                 trace!("removing closed connection for {:?}", self.key);
                 continue;
             }
@@ -341,6 +342,7 @@ impl<'a, T: Poolable + 'a> IdlePopper<'a, T> {
             // In that case, we could just break out of the loop and drop the
             // whole list...
             if expiration.expires(entry.idle_at) {
+                error!("IdlePopper; remove expired conn | key: {:?}", self.key);
                 trace!("removing expired connection for {:?}", self.key);
                 continue;
             }
@@ -528,10 +530,12 @@ impl<T: Poolable> Connections<T> {
         self.idle.retain(|key, values| {
             values.retain(|entry| {
                 if !entry.value.is_open() {
+                    error!("clear_expired; remove closed conn | key: {:?}", key);
                     trace!("idle interval evicting closed for {:?}", key);
                     return false;
                 }
                 if now - entry.idle_at > dur {
+                    error!("clear_expired; remove expired conn | key: {:?}", key);
                     trace!("idle interval evicting expired for {:?}", key);
                     return false;
                 }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -136,14 +136,14 @@ impl<T> Pool<T> {
 #[derive(Debug)]
 pub(super) enum ConnectingError {
     Http2InProgress,
-    Http1TooManyIdle,
+    Http1TooManyConnections,
 }
 
 impl Error for ConnectingError {
     fn description(&self) -> &str {
         match self {
             ConnectingError::Http2InProgress => { "HTTP/2 connecting already in progress" },
-            ConnectingError::Http1TooManyIdle => { "HTTP/1 too many idle connections" },
+            ConnectingError::Http1TooManyConnections => { "HTTP/1 too many connections" },
         }
     }
 }
@@ -152,7 +152,7 @@ impl fmt::Display for ConnectingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ConnectingError::Http2InProgress => { write!(f, "HTTP/2 connecting already in progress") },
-            ConnectingError::Http1TooManyIdle => { write!(f, "HTTP/1 too many idle connections") },
+            ConnectingError::Http1TooManyConnections => { write!(f, "HTTP/1 too many connections") },
         }
     }
 }
@@ -220,8 +220,8 @@ impl<T: Poolable> Pool<T> {
                         counter: Some(counter),
                     })
                 } else {
-                    trace!("HTTP/1 too many idle connections, will return wait");
-                    Err(ConnectingError::Http1TooManyIdle)
+                    trace!("HTTP/1 too many connections, will return wait");
+                    Err(ConnectingError::Http1TooManyConnections)
                 }
             },
         }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -429,7 +429,7 @@ impl<T: Poolable> Connections<T> {
 
         match (value, counter) {
             (Some(value), Some(counter)) => {
-                error!("pooling idle connection for {:?}", key);
+                trace!("pooling idle connection for {:?}", key);
                 self.idle.entry(key)
                      .or_insert(Vec::new())
                      .push(Idle {

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -310,13 +310,13 @@ impl<T: Poolable> Pool<T> {
         }
     }
 
-    // fn waiter(&mut self, key: Key, tx: oneshot::Sender<(T, Option<Counter>)>) {
-    //     trace!("checkout waiting for idle connection: {:?}", key);
-    //     self.inner.connections.lock().unwrap()
-    //         .waiters.entry(key)
-    //         .or_insert(VecDeque::new())
-    //         .push_back(tx);
-    // }
+    fn waiter(&mut self, key: Key, tx: oneshot::Sender<(T, Option<Counter>)>) {
+        trace!("checkout waiting for idle connection: {:?}", key);
+        self.inner.connections.lock().unwrap()
+            .waiters.entry(key)
+            .or_insert(VecDeque::new())
+            .push_back(tx);
+    }
 }
 
 /// Pop off this list, looking for a usable connection that hasn't expired.
@@ -652,36 +652,36 @@ pub(super) struct Checkout<T> {
 }
 
 impl<T: Poolable> Checkout<T> {
-    // fn poll_waiter(&mut self) -> Poll<Option<Pooled<T>>, ::Error> {
-    //     static CANCELED: &str = "pool checkout failed";
-    //     if let Some(mut rx) = self.waiter.take() {
-    //         match rx.poll() {
-    //             Ok(Async::Ready((value, counter))) => {
-    //                 if value.is_open() {
-    //                     Ok(Async::Ready(Some(self.pool.reuse(&self.key, value, counter))))
-    //                 } else {
-    //                     Err(::Error::new_canceled(Some(CANCELED)))
-    //                 }
-    //             },
-    //             Ok(Async::NotReady) => {
-    //                 self.waiter = Some(rx);
-    //                 Ok(Async::NotReady)
-    //             },
-    //             Err(_canceled) => Err(::Error::new_canceled(Some(CANCELED))),
-    //         }
-    //     } else {
-    //         Ok(Async::Ready(None))
-    //     }
-    // }
+    fn poll_waiter(&mut self) -> Poll<Option<Pooled<T>>, ::Error> {
+        static CANCELED: &str = "pool checkout failed";
+        if let Some(mut rx) = self.waiter.take() {
+            match rx.poll() {
+                Ok(Async::Ready((value, counter))) => {
+                    if value.is_open() {
+                        Ok(Async::Ready(Some(self.pool.reuse(&self.key, value, counter))))
+                    } else {
+                        Err(::Error::new_canceled(Some(CANCELED)))
+                    }
+                },
+                Ok(Async::NotReady) => {
+                    self.waiter = Some(rx);
+                    Ok(Async::NotReady)
+                },
+                Err(_canceled) => Err(::Error::new_canceled(Some(CANCELED))),
+            }
+        } else {
+            Ok(Async::Ready(None))
+        }
+    }
 
-    // fn add_waiter(&mut self) {
-    //     if self.waiter.is_none() {
-    //         let (tx, mut rx) = oneshot::channel();
-    //         let _ = rx.poll(); // park this task
-    //         self.pool.waiter(self.key.clone(), tx);
-    //         self.waiter = Some(rx);
-    //     }
-    // }
+    fn add_waiter(&mut self) {
+        if self.waiter.is_none() {
+            let (tx, mut rx) = oneshot::channel();
+            let _ = rx.poll(); // park this task
+            self.pool.waiter(self.key.clone(), tx);
+            self.waiter = Some(rx);
+        }
+    }
 }
 
 impl<T: Poolable> Future for Checkout<T> {
@@ -689,16 +689,16 @@ impl<T: Poolable> Future for Checkout<T> {
     type Error = ::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        // if let Some(pooled) = try_ready!(self.poll_waiter()) {
-        //     return Ok(Async::Ready(pooled));
-        // }
+        if let Some(pooled) = try_ready!(self.poll_waiter()) {
+            return Ok(Async::Ready(pooled));
+        }
 
         let entry = self.pool.take(&self.key);
 
         if let Some(pooled) = entry {
             Ok(Async::Ready(pooled))
         } else {
-            // self.add_waiter();
+            self.add_waiter();
             Ok(Async::NotReady)
         }
     }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -429,7 +429,7 @@ impl<T: Poolable> Connections<T> {
 
         match (value, counter) {
             (Some(value), Some(counter)) => {
-                debug!("pooling idle connection for {:?}", key);
+                error!("pooling idle connection for {:?}", key);
                 self.idle.entry(key)
                      .or_insert(Vec::new())
                      .push(Idle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate httparse;
 extern crate iovec;
 #[macro_use] extern crate log;
 #[cfg(feature = "runtime")] extern crate net2;
+extern crate raii_counter;
 extern crate time;
 #[cfg(feature = "runtime")] extern crate tokio;
 #[cfg(feature = "runtime")] extern crate tokio_executor;

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -189,6 +189,7 @@ where
             Ok(Async::NotReady) => unreachable!("dispatch not ready when conn is"),
             Err(()) => {
                 trace!("dispatch no longer receiving messages");
+                error!("conn close - 1 - no longer receiving messages");
                 self.close();
                 return Ok(Async::Ready(()));
             }
@@ -441,6 +442,7 @@ where
                 match cb.poll_cancel().expect("poll_cancel cannot error") {
                     Async::Ready(()) => {
                         trace!("request canceled");
+                        error!("conn close - 2B - poll_msg none - request canceled");
                         Ok(Async::Ready(None))
                     },
                     Async::NotReady => {
@@ -458,6 +460,8 @@ where
             Ok(Async::Ready(None)) => {
                 trace!("client tx closed");
                 // user has dropped sender handle
+
+                error!("conn close - 2A - poll_msg none - client tx closed");
                 Ok(Async::Ready(None))
             },
             Ok(Async::NotReady) => return Ok(Async::NotReady),


### PR DESCRIPTION
Add `max_connections` to `hyper::Client` builder + keep track of connections through `hyper::Client::Pool`.

If there too many connections, sending a new HTTP/1 request will not create a new connection, but will instead wait for an idle connection (if possible). Otherwise the request will fail.